### PR TITLE
Solve the missing 3 argument error

### DIFF
--- a/src/Mongo/Mongodb/Collection.php
+++ b/src/Mongo/Mongodb/Collection.php
@@ -32,9 +32,9 @@ class Collection extends \MongoDB\Collection{
     public function __construct(Connection $connection, $namespace)
     {
         $this->connection = $connection;
-        $this->namespace = $this->connection->getNameDatabase().".".$namespace;
+        $this->namespace = $namespace;
 
-        parent::__construct($connection->getManager(), $this->namespace);
+        parent::__construct($this->connection->getManager(), $this->connection->getNameDatabase(), $this->namespace);
     }
 
 


### PR DESCRIPTION
Solve the missing 3 argument error in the Collection class __construct method in MongoDB/MongoDB packgage.
